### PR TITLE
new: Use `-jc` flag to clear injected documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,14 @@ clean:
 	rm -f *.tar.gz
 
 build: clean
-	# Backup the original modules
-	cp -r plugins plugins_tmp
+	# Generate and inject the documentation
 	./scripts/inject_docs.sh
 
 	# Build the collection
 	-ansible-galaxy collection build
 
-	# Restore the original modules
-	rm -rf plugins
-	mv plugins_tmp plugins
+	# Remove the generated docs
+	./scripts/clear_docs.sh
 
 publish: build
 	@if test "$(GALAXY_TOKEN)" = ""; then \
@@ -35,16 +33,14 @@ deps:
 sanity:
 	python3 ./scripts/generate_sanity_ignores.py
 
-	# Backup the original modules
-	cp -r plugins plugins_tmp
+	# Generate and inject the documentation
 	./scripts/inject_docs.sh
 
 	# Run sanity tests
 	-ansible-test sanity
 
-	# Restore the original modules
-	rm -rf plugins
-	mv plugins_tmp plugins
+	# Remove the generated docs
+	./scripts/clear_docs.sh
 
 lint:
 	pylint plugins

--- a/plugins/modules/file.py
+++ b/plugins/modules/file.py
@@ -8,11 +8,14 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 # These will be populated at build-time
-DOCUMENTATION = """"""
+DOCUMENTATION = '''
+'''
 
-RETURN = """"""
+RETURN = '''
+'''
 
-EXAMPLES = """"""
+EXAMPLES = '''
+'''
 
 import os
 from typing import List

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible-specdoc==0.0.12
+ansible-specdoc==0.0.13

--- a/scripts/clear_docs.sh
+++ b/scripts/clear_docs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for f in plugins/modules/*.py
+do
+  PYTHONWARNINGS="ignore" ansible-specdoc -i "$f" -jc; #> /dev/null || exit 1;
+done

--- a/scripts/generate_sanity_ignores.py
+++ b/scripts/generate_sanity_ignores.py
@@ -16,6 +16,7 @@ parsed_version = version.parse(ansible_version)
 
 with open(f"tests/sanity/ignore-{parsed_version.major}.{parsed_version.minor}.txt", "w") as file:
     file.write("scripts/inject_docs.sh shebang\n")
+    file.write("scripts/clear_docs.sh shebang\n")
     file.write("scripts/generate_sanity_ignores.py shebang\n")
 
     for plugin_file in glob.glob("plugins/**/*.py", recursive=True):

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,4 +1,5 @@
 scripts/inject_docs.sh shebang
+scripts/clear_docs.sh shebang
 scripts/generate_sanity_ignores.py shebang
 plugins/module_utils/base_module.py import-3.8!skip
 plugins/module_utils/base_module.py import-3.9!skip


### PR DESCRIPTION
## 📝 Description

This change alters the `make build` and `make sanity` targets to clean up using the `-jc` flag rather than using a temporary directory. This makes the build and sanity check processes far less prone to failure and less likely to corrupt the project is a job is cancelled prematurely.

## ✔️ How to Test

```
make build
make sanity
```
